### PR TITLE
Fixed the hyperlinks to the Zora social media profiles and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 Internet Renaissance.
 
-**Website:** [zora.co](zora.co)
-**Instagram:** [@our.zora](instagram.com/our.zora)
-**Twitter:** [@ourZORA](twitter.com/ourZORA)
+**Website:** [zora.co](https://zora.co)
+**Instagram:** [@our.zora](https://instagram.com/our.zora)
+**Twitter:** [@ourZORA](https://twitter.com/ourZORA)
 
 ## Purpose
 


### PR DESCRIPTION
GitHub thought the links were supposed to go to files in the repo. Adding `https://` fixes this.